### PR TITLE
Fix login form function error

### DIFF
--- a/index.html
+++ b/index.html
@@ -2136,8 +2136,6 @@
       }
     }
 
-    }
-
     // Open Task Link Function
     window.openTaskLink = function(link, taskId, taskType) {
       if (!link) {


### PR DESCRIPTION
Remove an extra closing brace in `index.html` to fix a JavaScript syntax error that prevented login form functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-3a605ef2-6daf-49a4-97f6-d2813fbd4971"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3a605ef2-6daf-49a4-97f6-d2813fbd4971"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

